### PR TITLE
show toast instead of dialog on media download success

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
@@ -23,6 +23,8 @@ package com.vitorpamplona.amethyst.ui.components
 import android.Manifest
 import android.content.Context
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
@@ -301,6 +303,15 @@ private fun DialogContent(
     }
 }
 
+private fun showToastOnMain(
+    context: Context,
+    resId: Int,
+) {
+    Handler(Looper.getMainLooper()).post {
+        Toast.makeText(context.applicationContext, resId, Toast.LENGTH_SHORT).show()
+    }
+}
+
 private suspend fun saveMediaToGallery(
     content: BaseMediaContent,
     localContext: Context,
@@ -324,7 +335,7 @@ private suspend fun saveMediaToGallery(
             },
             localContext,
             onSuccess = {
-                accountViewModel.toastManager.toast(success, success)
+                showToastOnMain(localContext, success)
             },
             onError = {
                 accountViewModel.toastManager.toast(failure, null, it)
@@ -337,7 +348,7 @@ private suspend fun saveMediaToGallery(
                 content.mimeType,
                 localContext,
                 onSuccess = {
-                    accountViewModel.toastManager.toast(success, success)
+                    showToastOnMain(localContext, success)
                 },
                 onError = { innerIt ->
                     accountViewModel.toastManager.toast(failure, null, innerIt)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -23,7 +23,10 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.drawable.Drawable
+import android.os.Handler
+import android.os.Looper
 import android.util.LruCache
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
@@ -1709,7 +1712,11 @@ class AccountViewModel(
                 mimeType = mimeType,
                 localContext = localContext,
                 onSuccess = {
-                    toastManager.toast(R.string.video_saved_to_the_gallery, R.string.video_saved_to_the_gallery)
+                    Handler(Looper.getMainLooper()).post {
+                        Toast
+                            .makeText(localContext.applicationContext, R.string.video_saved_to_the_gallery, Toast.LENGTH_SHORT)
+                            .show()
+                    }
                 },
                 onError = {
                     toastManager.toast(R.string.failed_to_save_the_video, null, it)


### PR DESCRIPTION
Replace the interruptive AlertDialog with a brief Android Toast when
media downloads complete. Errors still show the full dialog for visibility. 