### PR TITLE
fix(quartz): validate event id, pubKey, sig hex/length and kind range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,7 @@ TASKS.md
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Downloaded VLC binaries (vlc-setup plugin)
 desktopApp/src/jvmMain/appResources/linux/

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
@@ -101,10 +101,6 @@ object EventKSerializer : KSerializer<Event> {
             }
         }
 
-        if (pubKey.isEmpty()) {
-            throw IllegalArgumentException("Event not found")
-        }
-
         EventLimits.validateFields(id, pubKey, sig, kind)
         EventLimits.validateContent(content)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
@@ -105,6 +105,7 @@ object EventKSerializer : KSerializer<Event> {
             throw IllegalArgumentException("Event not found")
         }
 
+        EventLimits.validateFields(id, pubKey, sig, kind)
         EventLimits.validateContent(content)
 
         return EventFactory.create(id, pubKey, createdAt, kind, tags, content, sig)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimits.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimits.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.quartz.nip01Core.limits
 
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.utils.Hex
 
 // Defense-in-depth caps on relay-supplied event payloads.
 // A hostile relay can otherwise OOM the client with one giant event or a flood of large tags
@@ -37,9 +38,47 @@ object EventLimits {
     const val MAX_CONTENT_LENGTH = 64 * 1024
     const val MAX_RELAY_MESSAGE_LENGTH = 256 * 1024
 
+    // NIP-01 declares `kind` as an unsigned 16-bit integer (0..65 535).
+    const val MAX_KIND = 65_535
+
     fun validateContent(content: String) {
         require(content.length <= MAX_CONTENT_LENGTH) {
             "Event content length ${content.length} exceeds max $MAX_CONTENT_LENGTH"
+        }
+    }
+
+    // Validates structural fields of an Event after deserialization (security review
+    // 2026-04-24 §2.4 / Finding #11). Without this, malformed events sit in the cache
+    // permanently and only blow up later inside Hex.decode if signature verification
+    // ever runs.
+    //
+    // - `id`/`pubKey`: required 64-char hex (32-byte hashes / x-only pubkeys).
+    // - `sig`: 128-char hex (64-byte Schnorr signature) when present, OR empty.
+    //   NIP-17 (kind:14 DMs) and NIP-37 drafts are stored as Event with sig="" because
+    //   the inner-event rumor is unsigned per NIP-59; we'd reject ~5 K real DMs from
+    //   any production cache otherwise. Signature verification (security review §2.1)
+    //   handles the "must be signed if non-empty" semantic.
+    // - `kind`: NIP-01 u16 range.
+    //
+    // `createdAt` is intentionally not bounded here: it's a UI / feed-sort concern, and
+    // archive replay legitimately produces events with timestamps from years ago.
+    fun validateFields(
+        id: String,
+        pubKey: String,
+        sig: String,
+        kind: Int,
+    ) {
+        require(id.length == 64 && Hex.isHex64(id)) {
+            "Event id must be 64-char hex; got length=${id.length}"
+        }
+        require(pubKey.length == 64 && Hex.isHex64(pubKey)) {
+            "Event pubKey must be 64-char hex; got length=${pubKey.length}"
+        }
+        require(sig.isEmpty() || (sig.length == 128 && Hex.isHex(sig))) {
+            "Event sig must be empty or 128-char hex; got length=${sig.length}"
+        }
+        require(kind in 0..MAX_KIND) {
+            "Event kind $kind out of range [0, $MAX_KIND]"
         }
     }
 

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
@@ -24,115 +24,60 @@ import com.vitorpamplona.quartz.nip01Core.kotlinSerialization.KotlinSerializatio
 import com.vitorpamplona.quartz.nip01Core.limits.EventLimitsTestSupport.buildEventJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
-// Regression for security review 2026-04-24 §2.3 / Finding #5: the deserializers used to
-// materialize whole events with no upper bound. A hostile relay could OOM the client with
-// one giant event or a flood of large tags. Caps are enforced inline by the tag deserializers
-// and post-parse by EventLimits.validateContent.
+// Regression for security review 2026-04-24 §2.3 / Finding #5 + §2.4 / Finding #11.
+// Exercises the kotlinx path; JacksonEventDeserializerLimitsTest mirrors this against the
+// streaming Jackson parser.
 class EventLimitsTest {
     private fun parse(json: String) = KotlinSerializationMapper.fromJson(json)
 
     @Test
     fun acceptsEventWithinLimits() {
-        val event =
-            parse(buildEventJson(contentLength = 100, tagCount = 5, tagInnerCount = 3, tagValueLength = 50))
+        val event = parse(buildEventJson(contentLength = 100, tagCount = 5, tagInnerCount = 3, tagValueLength = 50))
         assertEquals(5, event.tags.size)
         assertEquals(100, event.content.length)
         assertEquals(3, event.tags[0].size)
     }
 
-    @Test
-    fun rejectsOversizedContent() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(contentLength = EventLimits.MAX_CONTENT_LENGTH + 1))
-            }
-        assertEquals(true, ex.message?.contains("content length"), ex.message)
-    }
+    // --- §2.3: size / count / length caps ---
 
     @Test
-    fun rejectsTooManyTags() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(tagCount = EventLimits.MAX_TAG_COUNT + 1))
-            }
-        assertEquals(true, ex.message?.contains("tags"), ex.message)
-    }
+    fun rejectsOversizedContent() = assertRejectsBecause(::parse, buildEventJson(contentLength = EventLimits.MAX_CONTENT_LENGTH + 1), "content length")
 
     @Test
-    fun rejectsTagWithTooManyElements() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(tagInnerCount = EventLimits.MAX_TAG_ELEMENTS_PER_TAG + 2))
-            }
-        assertEquals(true, ex.message?.contains("elements"), ex.message)
-    }
+    fun rejectsTooManyTags() = assertRejectsBecause(::parse, buildEventJson(tagCount = EventLimits.MAX_TAG_COUNT + 1), "tags")
 
     @Test
-    fun rejectsOversizedTagValue() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(tagValueLength = EventLimits.MAX_TAG_VALUE_LENGTH + 1))
-            }
-        assertEquals(true, ex.message?.contains("Tag value length"), ex.message)
-    }
-
-    // --- §2.4: id / pubKey / sig / kind / createdAt validation ---
+    fun rejectsTagWithTooManyElements() = assertRejectsBecause(::parse, buildEventJson(tagInnerCount = EventLimits.MAX_TAG_ELEMENTS_PER_TAG + 2), "elements")
 
     @Test
-    fun rejectsIdWithWrongLength() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(id = "0".repeat(63)))
-            }
-        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
-    }
+    fun rejectsOversizedTagValue() = assertRejectsBecause(::parse, buildEventJson(tagValueLength = EventLimits.MAX_TAG_VALUE_LENGTH + 1), "Tag value length")
+
+    // --- §2.4: id / pubKey / sig / kind validation ---
 
     @Test
-    fun rejectsIdWithNonHex() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(id = "z".repeat(64)))
-            }
-        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
-    }
+    fun rejectsIdWithWrongLength() = assertRejectsBecause(::parse, buildEventJson(id = "0".repeat(63)), "id must be 64-char hex")
 
     @Test
-    fun rejectsPubKeyWithWrongLength() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(pubKey = "0".repeat(65)))
-            }
-        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
-    }
+    fun rejectsIdWithNonHex() = assertRejectsBecause(::parse, buildEventJson(id = "z".repeat(64)), "id must be 64-char hex")
 
     @Test
-    fun rejectsPubKeyWithNonHex() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(pubKey = "g".repeat(64)))
-            }
-        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
-    }
+    fun rejectsPubKeyWithWrongLength() = assertRejectsBecause(::parse, buildEventJson(pubKey = "0".repeat(65)), "pubKey must be 64-char hex")
 
     @Test
-    fun rejectsSigWithWrongNonZeroLength() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(sig = "0".repeat(127)))
-            }
-        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
-    }
+    fun rejectsPubKeyWithNonHex() = assertRejectsBecause(::parse, buildEventJson(pubKey = "g".repeat(64)), "pubKey must be 64-char hex")
 
     @Test
-    fun rejectsSigWithNonHex() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(sig = "z".repeat(128)))
-            }
-        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
-    }
+    fun rejectsSigWithWrongNonZeroLength() = assertRejectsBecause(::parse, buildEventJson(sig = "0".repeat(127)), "sig must be empty or 128-char hex")
+
+    @Test
+    fun rejectsSigWithNonHex() = assertRejectsBecause(::parse, buildEventJson(sig = "z".repeat(128)), "sig must be empty or 128-char hex")
+
+    @Test
+    fun rejectsKindAboveMax() = assertRejectsBecause(::parse, buildEventJson(kind = EventLimits.MAX_KIND + 1), "kind")
+
+    @Test
+    fun rejectsKindBelowZero() = assertRejectsBecause(::parse, buildEventJson(kind = -1), "kind")
 
     @Test
     fun acceptsEmptySig() {
@@ -144,27 +89,9 @@ class EventLimitsTest {
     }
 
     @Test
-    fun rejectsKindAboveMax() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(kind = EventLimits.MAX_KIND + 1))
-            }
-        assertEquals(true, ex.message?.contains("kind"), ex.message)
-    }
-
-    @Test
-    fun rejectsKindBelowZero() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(kind = -1))
-            }
-        assertEquals(true, ex.message?.contains("kind"), ex.message)
-    }
-
-    @Test
     fun acceptsAncientCreatedAt() {
         // Archive replay legitimately produces events with timestamps from years ago.
-        // The deserializer doesn't bound createdAt; UI / feed-sort code can apply policy.
+        // The deserializer doesn't bound createdAt; UI / feed-sort code applies policy.
         val event = parse(buildEventJson(createdAt = 100L))
         assertEquals(100L, event.createdAt)
     }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
@@ -77,4 +77,95 @@ class EventLimitsTest {
             }
         assertEquals(true, ex.message?.contains("Tag value length"), ex.message)
     }
+
+    // --- §2.4: id / pubKey / sig / kind / createdAt validation ---
+
+    @Test
+    fun rejectsIdWithWrongLength() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(id = "0".repeat(63)))
+            }
+        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsIdWithNonHex() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(id = "z".repeat(64)))
+            }
+        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsPubKeyWithWrongLength() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(pubKey = "0".repeat(65)))
+            }
+        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsPubKeyWithNonHex() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(pubKey = "g".repeat(64)))
+            }
+        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsSigWithWrongNonZeroLength() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(sig = "0".repeat(127)))
+            }
+        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsSigWithNonHex() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(sig = "z".repeat(128)))
+            }
+        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
+    }
+
+    @Test
+    fun acceptsEmptySig() {
+        // NIP-17 (kind:14 DMs) and NIP-37 drafts are stored as Event with sig="" because
+        // the inner-event rumor is unsigned per NIP-59. Production caches contain ~5 K
+        // such events; the deserializer must accept them.
+        val event = parse(buildEventJson(sig = ""))
+        assertEquals("", event.sig)
+    }
+
+    @Test
+    fun rejectsKindAboveMax() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(kind = EventLimits.MAX_KIND + 1))
+            }
+        assertEquals(true, ex.message?.contains("kind"), ex.message)
+    }
+
+    @Test
+    fun rejectsKindBelowZero() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(kind = -1))
+            }
+        assertEquals(true, ex.message?.contains("kind"), ex.message)
+    }
+
+    @Test
+    fun acceptsAncientCreatedAt() {
+        // Archive replay legitimately produces events with timestamps from years ago.
+        // The deserializer doesn't bound createdAt; UI / feed-sort code can apply policy.
+        val event = parse(buildEventJson(createdAt = 100L))
+        assertEquals(100L, event.createdAt)
+    }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTestSupport.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTestSupport.kt
@@ -20,7 +20,19 @@
  */
 package com.vitorpamplona.quartz.nip01Core.limits
 
+import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal fun assertRejectsBecause(
+    parse: (String) -> Event,
+    json: String,
+    expectedMessageFragment: String,
+) {
+    val ex = assertFailsWith<IllegalArgumentException> { parse(json) }
+    assertEquals(true, ex.message?.contains(expectedMessageFragment), ex.message)
+}
 
 internal object EventLimitsTestSupport {
     const val ID = "0000000000000000000000000000000000000000000000000000000000000001"

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTestSupport.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTestSupport.kt
@@ -20,12 +20,19 @@
  */
 package com.vitorpamplona.quartz.nip01Core.limits
 
+import com.vitorpamplona.quartz.utils.TimeUtils
+
 internal object EventLimitsTestSupport {
     const val ID = "0000000000000000000000000000000000000000000000000000000000000001"
     const val PUB_KEY = "0000000000000000000000000000000000000000000000000000000000000002"
     val SIG = "0".repeat(128)
 
     fun buildEventJson(
+        id: String = ID,
+        pubKey: String = PUB_KEY,
+        sig: String = SIG,
+        kind: Int = 1,
+        createdAt: Long = TimeUtils.now(),
         contentLength: Int = 10,
         tagCount: Int = 1,
         tagInnerCount: Int = 2,
@@ -37,6 +44,6 @@ internal object EventLimitsTestSupport {
         val inner = "\"t\"" + ",\"$tagValue\"".repeat((tagInnerCount - 1).coerceAtLeast(0))
         val tag = "[$inner]"
         val tags = (1..tagCount).joinToString(",") { tag }
-        return """{"id":"$ID","pubkey":"$PUB_KEY","created_at":1,"kind":1,"tags":[$tags],"content":"$content","sig":"$SIG"}"""
+        return """{"id":"$id","pubkey":"$pubKey","created_at":$createdAt,"kind":$kind,"tags":[$tags],"content":"$content","sig":"$sig"}"""
     }
 }

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
@@ -74,10 +74,6 @@ class EventDeserializer : StdDeserializer<Event>(Event::class.java) {
             }
         }
 
-        if (pubKey.isEmpty()) {
-            throw IllegalArgumentException("Event not found")
-        }
-
         EventLimits.validateFields(id, pubKey, sig, kind)
         EventLimits.validateContent(content)
 

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
@@ -78,6 +78,7 @@ class EventDeserializer : StdDeserializer<Event>(Event::class.java) {
             throw IllegalArgumentException("Event not found")
         }
 
+        EventLimits.validateFields(id, pubKey, sig, kind)
         EventLimits.validateContent(content)
 
         return EventFactory.create(id, pubKey, createdAt, kind, tags, content, sig)

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/KotlinSerializationMapperTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/KotlinSerializationMapperTest.kt
@@ -180,12 +180,15 @@ class KotlinSerializationMapperTest {
 
     @Test
     fun deserializeEventWithUnknownFields() {
+        val id = "a".repeat(64)
+        val pubKey = "b".repeat(64)
+        val sig = "c".repeat(128)
         val json =
-            """{"id":"abc123","pubkey":"def456","created_at":12345,"kind":1,"tags":[],"content":"test","sig":"sig123","unknown_field":"ignored"}"""
+            """{"id":"$id","pubkey":"$pubKey","created_at":12345,"kind":1,"tags":[],"content":"test","sig":"$sig","unknown_field":"ignored"}"""
         // Should not throw with unknown fields, should be ignored
         val deserialized = KotlinSerializationMapper.fromJson(json)
-        assertEquals("abc123", deserialized.id)
-        assertEquals("def456", deserialized.pubKey)
+        assertEquals(id, deserialized.id)
+        assertEquals(pubKey, deserialized.pubKey)
         assertEquals("test", deserialized.content)
     }
 
@@ -194,12 +197,12 @@ class KotlinSerializationMapperTest {
         val content = "Hello \"world\" \n\ttab\\backslash"
         val event =
             FollowListEvent(
-                id = "abc",
-                pubKey = "def",
+                id = "a".repeat(64),
+                pubKey = "b".repeat(64),
                 createdAt = 1000,
                 tags = emptyArray(),
                 content = content,
-                sig = "sig",
+                sig = "c".repeat(128),
             )
         val json = KotlinSerializationMapper.toJson(event)
         val deserialized = KotlinSerializationMapper.fromJson(json)
@@ -684,7 +687,7 @@ class KotlinSerializationMapperTest {
                 createdAt = 0,
                 tags = emptyArray(),
                 content = "",
-                sig = "c".repeat(64),
+                sig = "c".repeat(128),
             )
         val json = KotlinSerializationMapper.toJson(event)
         val deserialized = KotlinSerializationMapper.fromJson(json)
@@ -711,7 +714,7 @@ class KotlinSerializationMapperTest {
                 createdAt = 1000,
                 tags = emptyArray(),
                 content = content,
-                sig = "c".repeat(64),
+                sig = "c".repeat(128),
             )
         val json = KotlinSerializationMapper.toJson(event)
         val deserialized = KotlinSerializationMapper.fromJson(json)

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
@@ -24,14 +24,12 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 import com.vitorpamplona.quartz.nip01Core.limits.EventLimitsTestSupport.buildEventJson
+import com.vitorpamplona.quartz.nip01Core.limits.assertRejectsBecause
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
-// Jackson-path coverage for security review 2026-04-24 §2.3 / Finding #5.
-// The kotlinx path is exercised by EventLimitsTest in commonTest; this file targets the
-// streaming Jackson deserializers (EventDeserializer + TagArrayDeserializer) which terminate
-// the parse early on cap overflow.
+// Jackson-path mirror of EventLimitsTest (commonTest, kotlinx path). Shared assertion helper
+// from EventLimitsTestSupport keeps the two classes aligned.
 class JacksonEventDeserializerLimitsTest {
     private fun parse(json: String): Event = JacksonMapper.mapper.readValue(json)
 
@@ -42,121 +40,50 @@ class JacksonEventDeserializerLimitsTest {
         assertEquals(100, event.content.length)
     }
 
-    @Test
-    fun rejectsOversizedContent() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(contentLength = EventLimits.MAX_CONTENT_LENGTH + 1))
-            }
-        assertEquals(true, ex.message?.contains("content length"), ex.message)
-    }
+    // --- §2.3: size / count / length caps ---
 
     @Test
-    fun rejectsTooManyTags() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(tagCount = EventLimits.MAX_TAG_COUNT + 1))
-            }
-        assertEquals(true, ex.message?.contains("tags"), ex.message)
-    }
+    fun rejectsOversizedContent() = assertRejectsBecause(::parse, buildEventJson(contentLength = EventLimits.MAX_CONTENT_LENGTH + 1), "content length")
 
     @Test
-    fun rejectsTagWithTooManyElements() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(tagInnerCount = EventLimits.MAX_TAG_ELEMENTS_PER_TAG + 2))
-            }
-        assertEquals(true, ex.message?.contains("elements"), ex.message)
-    }
+    fun rejectsTooManyTags() = assertRejectsBecause(::parse, buildEventJson(tagCount = EventLimits.MAX_TAG_COUNT + 1), "tags")
 
     @Test
-    fun rejectsOversizedTagValue() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(tagValueLength = EventLimits.MAX_TAG_VALUE_LENGTH + 1))
-            }
-        assertEquals(true, ex.message?.contains("Tag value length"), ex.message)
-    }
-
-    // --- §2.4: id / pubKey / sig / kind / createdAt validation ---
+    fun rejectsTagWithTooManyElements() = assertRejectsBecause(::parse, buildEventJson(tagInnerCount = EventLimits.MAX_TAG_ELEMENTS_PER_TAG + 2), "elements")
 
     @Test
-    fun rejectsIdWithWrongLength() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(id = "0".repeat(63)))
-            }
-        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
-    }
+    fun rejectsOversizedTagValue() = assertRejectsBecause(::parse, buildEventJson(tagValueLength = EventLimits.MAX_TAG_VALUE_LENGTH + 1), "Tag value length")
+
+    // --- §2.4: id / pubKey / sig / kind validation ---
 
     @Test
-    fun rejectsIdWithNonHex() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(id = "z".repeat(64)))
-            }
-        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
-    }
+    fun rejectsIdWithWrongLength() = assertRejectsBecause(::parse, buildEventJson(id = "0".repeat(63)), "id must be 64-char hex")
 
     @Test
-    fun rejectsPubKeyWithWrongLength() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(pubKey = "0".repeat(65)))
-            }
-        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
-    }
+    fun rejectsIdWithNonHex() = assertRejectsBecause(::parse, buildEventJson(id = "z".repeat(64)), "id must be 64-char hex")
 
     @Test
-    fun rejectsPubKeyWithNonHex() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(pubKey = "g".repeat(64)))
-            }
-        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
-    }
+    fun rejectsPubKeyWithWrongLength() = assertRejectsBecause(::parse, buildEventJson(pubKey = "0".repeat(65)), "pubKey must be 64-char hex")
 
     @Test
-    fun rejectsSigWithWrongNonZeroLength() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(sig = "0".repeat(127)))
-            }
-        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
-    }
+    fun rejectsPubKeyWithNonHex() = assertRejectsBecause(::parse, buildEventJson(pubKey = "g".repeat(64)), "pubKey must be 64-char hex")
 
     @Test
-    fun rejectsSigWithNonHex() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(sig = "z".repeat(128)))
-            }
-        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
-    }
+    fun rejectsSigWithWrongNonZeroLength() = assertRejectsBecause(::parse, buildEventJson(sig = "0".repeat(127)), "sig must be empty or 128-char hex")
+
+    @Test
+    fun rejectsSigWithNonHex() = assertRejectsBecause(::parse, buildEventJson(sig = "z".repeat(128)), "sig must be empty or 128-char hex")
+
+    @Test
+    fun rejectsKindAboveMax() = assertRejectsBecause(::parse, buildEventJson(kind = EventLimits.MAX_KIND + 1), "kind")
+
+    @Test
+    fun rejectsKindBelowZero() = assertRejectsBecause(::parse, buildEventJson(kind = -1), "kind")
 
     @Test
     fun acceptsEmptySig() {
-        // NIP-17 (kind:14 DMs) and NIP-37 drafts are stored as Event with sig="".
         val event = parse(buildEventJson(sig = ""))
         assertEquals("", event.sig)
-    }
-
-    @Test
-    fun rejectsKindAboveMax() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(kind = EventLimits.MAX_KIND + 1))
-            }
-        assertEquals(true, ex.message?.contains("kind"), ex.message)
-    }
-
-    @Test
-    fun rejectsKindBelowZero() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(kind = -1))
-            }
-        assertEquals(true, ex.message?.contains("kind"), ex.message)
     }
 
     @Test

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
@@ -77,4 +77,91 @@ class JacksonEventDeserializerLimitsTest {
             }
         assertEquals(true, ex.message?.contains("Tag value length"), ex.message)
     }
+
+    // --- §2.4: id / pubKey / sig / kind / createdAt validation ---
+
+    @Test
+    fun rejectsIdWithWrongLength() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(id = "0".repeat(63)))
+            }
+        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsIdWithNonHex() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(id = "z".repeat(64)))
+            }
+        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsPubKeyWithWrongLength() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(pubKey = "0".repeat(65)))
+            }
+        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsPubKeyWithNonHex() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(pubKey = "g".repeat(64)))
+            }
+        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsSigWithWrongNonZeroLength() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(sig = "0".repeat(127)))
+            }
+        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsSigWithNonHex() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(sig = "z".repeat(128)))
+            }
+        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
+    }
+
+    @Test
+    fun acceptsEmptySig() {
+        // NIP-17 (kind:14 DMs) and NIP-37 drafts are stored as Event with sig="".
+        val event = parse(buildEventJson(sig = ""))
+        assertEquals("", event.sig)
+    }
+
+    @Test
+    fun rejectsKindAboveMax() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(kind = EventLimits.MAX_KIND + 1))
+            }
+        assertEquals(true, ex.message?.contains("kind"), ex.message)
+    }
+
+    @Test
+    fun rejectsKindBelowZero() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(kind = -1))
+            }
+        assertEquals(true, ex.message?.contains("kind"), ex.message)
+    }
+
+    @Test
+    fun acceptsAncientCreatedAt() {
+        val event = parse(buildEventJson(createdAt = 100L))
+        assertEquals(100L, event.createdAt)
+    }
 }


### PR DESCRIPTION
**Stacked PR.** Base = \`davotoula:fix/quartz-event-deserializer-caps\` (the §2.3 branch in PR vitorpamplona#2700). This PR cannot merge until #2700 lands. After #2700 merges, retarget the base of this PR to upstream/main.

Implements §2.4 of the Quartz security review (Finding #11) — post-parse hex/length/range validation of `Event` structural fields.

## Validation rules

`EventLimits.validateFields(id, pubKey, sig, kind)` is called post-parse from both Jackson `EventDeserializer` and kotlinx `EventKSerializer`:

| Field | Rule | Why |
|---|---|---|
| `id` | 64-char hex | 32-byte SHA-256 of the canonical event |
| `pubKey` | 64-char hex | x-only secp256k1 pubkey |
| `sig` | empty OR 128-char hex | NIP-17 (kind:14 DMs) and NIP-37 drafts are stored as \`Event\` with \`sig=\"\"\` because the inner-event rumor is unsigned per NIP-59; ~5 K such events exist in production caches |
| `kind` | \`0..65535\` | NIP-01 unsigned 16-bit |
| `createdAt` | **not bounded** | Nostr legitimately uses ancient and future timestamps (scheduled posts, archive replay, NIP-23 backdated long-form, NIP-03/1040 OpenTimestamp attestations). The id pre-image binds \`created_at\` to the signature, so \`verify()\` detects tampering; sort-order manipulation is a feed/UI concern |

Without this, malformed events sat in the cache permanently and only blew up later inside \`Hex.decode\` if signature verification ran.

## Implementation

- New: \`EventLimits.validateFields(...)\` + \`MAX_KIND\` constant.
- Wired into both deserializers post-parse, after the new (more informative) length-check supplants the old empty-pubKey early-throw.
- Test helper \`EventLimitsTestSupport\` extended with id/pubKey/sig/kind/createdAt overrides + new \`assertRejectsBecause(parse, json, fragment)\` helper.

## Test plan

- [x] \`EventLimitsTest\` (commonTest, kotlinx path) — 14 tests including 4 §2.3 carries and all §2.4 rejection cases + accepts-empty-sig + accepts-ancient-createdAt
- [x] \`JacksonEventDeserializerLimitsTest\` (jvmTest, Jackson path) — same matrix
- [x] Updated 4 fixtures in \`KotlinSerializationMapperTest\` from synthetic short hex to realistic 64/128-char hex
- [x] Full \`:quartz:jvmTest\` — **1901 / 188 suites all green** including \`LargeDBTests\` (248 K real events) and \`JacksonInternBehaviorTest\` from §2.3
- [x] kotlin-reviewer: APPROVE (0 CRITICAL / 0 HIGH; 1 MEDIUM cosmetic, 3 LOW notes)

## Commits

1. \`91f0122aa\` — fix: validate event id, pubKey, sig hex/length and kind range
2. \`d854f91e2\` — chore: gitignore .claude/scheduled_tasks.lock
3. \`b7f0c62ef\` — refactor: drop redundant pubKey-empty check + dedup limits tests (post-/simplify cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)