### PR TITLE
fix(amethyst): run git from rootDir in versionName detection so worktrees work

### DIFF
--- a/amethyst/build.gradle.kts
+++ b/amethyst/build.gradle.kts
@@ -8,10 +8,11 @@ plugins {
     alias(libs.plugins.googleKsp)
 }
 
-fun getCurrentBranch(): String =
+fun getCurrentBranch(workingDir: java.io.File): String =
     try {
         val process =
             ProcessBuilder("git", "rev-parse", "--abbrev-ref", "HEAD")
+                .directory(workingDir)
                 .redirectErrorStream(true)
                 .start()
         val branch =
@@ -19,15 +20,18 @@ fun getCurrentBranch(): String =
                 .bufferedReader()
                 .use { it.readText() }
                 .trim()
-        process.waitFor()
-        branch
+        val exitCode = process.waitFor()
+        if (exitCode != 0) "unknown" else branch
     } catch (e: Exception) {
         println("Could not determine git branch: ${e.message}")
         "unknown"
     }
 
-fun generateVersionName(baseVersion: String): String {
-    val currentBranch = getCurrentBranch()
+fun generateVersionName(
+    baseVersion: String,
+    workingDir: java.io.File,
+): String {
+    val currentBranch = getCurrentBranch(workingDir)
 
     if (currentBranch == "main" || currentBranch == "master" || currentBranch == "unknown" || currentBranch == "HEAD") {
         return baseVersion
@@ -73,7 +77,7 @@ android {
                 .get()
                 .toInt()
         versionCode = 447
-        versionName = generateVersionName(libs.versions.app.get())
+        versionName = generateVersionName(libs.versions.app.get(), rootDir)
         buildConfigField("String", "RELEASE_NOTES_ID", "\"8ec0d94550b5538115226c6858159b1115713c9c6ed942173bd4fd5d292d8ba6\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## What

`getCurrentBranch()` in `amethyst/build.gradle.kts` spawns `git rev-parse --abbrev-ref HEAD` via `ProcessBuilder` without setting a working directory, so the process inherits the Gradle daemon's CWD. When the daemon was started from a **git worktree** (or any directory other than the project root), git runs in the wrong place and prints `fatal: not a git repository`. Because `redirectErrorStream(true)` folds stderr into stdout, that message was treated as the "branch name": it got sanitized to dashes and truncated, surfacing as a version suffix like `fatal--not-a-git-rep` in installed builds.

## Fix

- Pass an explicit working directory to `ProcessBuilder.directory()` and call it with `rootDir`, so git always runs at the project root regardless of where the daemon started.
- Check the process exit code and fall back to `"unknown"` on any non-zero exit, so a future git failure degrades gracefully instead of leaking stderr into the version name.
- Thread `workingDir` through `generateVersionName(...)`.

## Why it matters

Worktree-based workflows (and CI setups that start the daemon outside the repo root) currently produce a corrupted `versionName`. After this change the branch is detected correctly and release/`main` builds keep their clean version string.

## Testing

- Built `:amethyst:installPlayBenchmark` from a git worktree and confirmed the `versionName` no longer contains the `fatal--not-a-git-rep` suffix.
- Single-file change to `amethyst/build.gradle.kts`; no runtime/app-code impact.
